### PR TITLE
Ensure vol_bnds is tight

### DIFF
--- a/tools/generate_gt.py
+++ b/tools/generate_gt.py
@@ -100,6 +100,7 @@ def compute_global_volume(args, cam_intr, cam_pose_list):
     # ======================================================================================================== #
     vol_bnds = np.zeros((3, 2))
     vol_bnds[:, 0] = np.inf
+    vol_bnds[:, 1] = -np.inf
 
     n_imgs = len(cam_pose_list.keys())
     if n_imgs > 200:

--- a/tools/generate_gt.py
+++ b/tools/generate_gt.py
@@ -99,6 +99,7 @@ def compute_global_volume(args, cam_intr, cam_pose_list):
     # frustums in the dataset
     # ======================================================================================================== #
     vol_bnds = np.zeros((3, 2))
+    vol_bnds[:, 0] = np.inf
 
     n_imgs = len(cam_pose_list.keys())
     if n_imgs > 200:


### PR DESCRIPTION
Current code will makes the minimum `vol_bnds` no less than 0, and maximum `vol_bnds` no smaller than 0.

If the scene is far from origin, current code will create a large voxel grid starting from origin, which is wasting vram.